### PR TITLE
deps: pin tracing* to commit 6cc6c47354ceeb47da7c95faa41c6d29b71b5f37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pin-project = "1"
 futures = "0.3"
 tracing = "0.1"
 prost = "0.7"
-tracing-tower = { git = "https://github.com/tokio-rs/tracing/", branch = "v0.1.x" }
+tracing-tower = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }
 
 [dev-dependencies]
 structopt = "0.3"
@@ -31,5 +31,5 @@ tracing-subscriber = "0.2"
 doc = []
 
 [patch.crates-io]
-tracing = { git = "https://github.com/tokio-rs/tracing/", branch = "v0.1.x" }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing/", branch = "v0.1.x" }
+tracing = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }
+tracing-subscriber = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }


### PR DESCRIPTION
In the main penumbra repo in https://github.com/penumbra-zone/penumbra/issues/94 we saw a build failure due to some upstream changes, so here I'm just pinning to a known good rev (see successful CI build here on the 6cc6c47354ceeb47da7c95faa41c6d29b71b5f37 commit here: https://github.com/penumbra-zone/penumbra/commit/1e1a022a51994b6305041964b6793a66da1ff458)