### PR TITLE
Remove tower-tracing dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ pin-project = "1"
 futures = "0.3"
 tracing = "0.1"
 prost = "0.9"
-tracing-tower = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }
 
 [dev-dependencies]
 structopt = "0.3"
@@ -28,6 +27,3 @@ tracing-subscriber = "0.2"
 [features]
 doc = []
 
-[patch.crates-io]
-tracing = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,8 +9,6 @@ use tokio::{
 };
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tower::{Service, ServiceExt};
-use tracing::Instrument;
-use tracing::Level;
 
 use tendermint::abci::MethodKind;
 
@@ -152,17 +150,18 @@ where
 
         loop {
             match listener.accept().await {
-                Ok((socket, addr)) => {
+                Ok((socket, _addr)) => {
                     // set parent: None for the connection span, as it should
                     // exist independently of the listener's spans.
-                    let span = tracing::span!(parent: None, Level::ERROR, "abci", ?addr);
+                    //let span = tracing::span!(parent: None, Level::ERROR, "abci", ?addr);
                     let conn = Connection {
                         consensus: self.consensus.clone(),
                         mempool: self.mempool.clone(),
                         info: self.info.clone(),
                         snapshot: self.snapshot.clone(),
                     };
-                    tokio::spawn(async move { conn.run(socket).await.unwrap() }.instrument(span));
+                    //tokio::spawn(async move { conn.run(socket).await.unwrap() }.instrument(span));
+                    tokio::spawn(async move { conn.run(socket).await.unwrap() });
                 }
                 Err(e) => {
                     tracing::warn!({ %e }, "error accepting new tcp connection");


### PR DESCRIPTION
Because that crate was never released, we pinned an obsolete version of tracing
from git, and that's now causing problems for a feature we don't actually use
any more.