### PR TITLE
update to tendermint 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Henry de Valence <hdevalence@penumbra.zone>"]
 edition = "2021"
 license = "MIT"
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.26.0"
-tendermint = "0.26.0"
+tendermint-proto = "0.27.0"
+tendermint = "0.27.0"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/examples/kvstore.rs
+++ b/examples/kvstore.rs
@@ -55,7 +55,7 @@ impl Service<Request> for KVStore {
             Request::ApplySnapshotChunk(_) => Response::ApplySnapshotChunk(Default::default()),
             // response::SetOption is missing a Default impl as of tm-rs 0.26
             Request::SetOption(_) => Response::SetOption(response::SetOption {
-                code: 0,
+                code: tendermint::abci::Code::Ok,
                 log: String::new(),
                 info: String::new(),
             }),
@@ -82,7 +82,7 @@ impl KVStore {
             version: "0.1.0".to_string(),
             app_version: 1,
             last_block_height: self.height.into(),
-            last_block_app_hash: self.app_hash.to_vec().into(),
+            last_block_app_hash: self.app_hash.to_vec().try_into().unwrap(),
         }
     }
 


### PR DESCRIPTION
This bumps the version to 0.3.0, since the `tendermint` crate is part of the public API.