### PR TITLE
tower-abci: prepare release `0.7.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ prost = "0.11"
 
 [dev-dependencies]
 structopt = "0.3"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3.17"
 
 [features]
 doc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Henry de Valence <hdevalence@penumbra.zone>"]
 edition = "2021"
 license = "MIT"
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.30.0"
-tendermint = "0.30.0"
+tendermint-proto = "0.31.1"
+tendermint = "0.31.1"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }


### PR DESCRIPTION
This PR bumps the `tracing-subscriber` (https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.17) and `tendermint-rs@0.31.1` crates.