### PR TITLE
cargo: bump to `tendermint-rs@0.32`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Henry de Valence <hdevalence@penumbra.zone>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.31.1"
-tendermint = "0.31.1"
+tendermint-proto = "0.32"
+tendermint = "0.32"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }


### PR DESCRIPTION
This PR bumps `tower-abci` to using `tendermint-rs@0.32` and prepare release `0.8`