### PR TITLE
Support Unix domain sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Henry de Valence <hdevalence@penumbra.zone>"]
 edition = "2021"
 license = "MIT"

--- a/examples/kvstore_37/main.rs
+++ b/examples/kvstore_37/main.rs
@@ -185,12 +185,11 @@ async fn main() {
     let server = server_builder.finish().unwrap();
 
     if let Some(uds_path) = opt.uds {
-        // Run the ABCI server.
         server.listen_unix(uds_path).await.unwrap();
     } else {
-        let tcp_addr = format!("{}:{}", opt.host, opt.port);
-
-        // Run the ABCI server.
-        server.listen_tcp(tcp_addr).await.unwrap();
+        server
+            .listen_tcp(format!("{}:{}", opt.host, opt.port))
+            .await
+            .unwrap();
     }
 }

--- a/src/v034/server.rs
+++ b/src/v034/server.rs
@@ -202,8 +202,8 @@ where
     // figure out how / if to return errors to tendermint
     async fn run(
         mut self,
-        stream: impl AsyncReadExt + std::marker::Unpin,
-        sink: impl AsyncWriteExt + std::marker::Unpin,
+        read: impl AsyncReadExt + std::marker::Unpin,
+        write: impl AsyncWriteExt + std::marker::Unpin,
     ) -> Result<(), BoxError> {
         tracing::info!("listening for requests");
 
@@ -211,7 +211,6 @@ where
 
         let (mut request_stream, mut response_sink) = {
             use crate::v034::codec::{Decode, Encode};
-            let (read, write) = (stream, sink);
             (
                 FramedRead::new(read, Decode::<pb::Request>::default()),
                 FramedWrite::new(write, Encode::<pb::Response>::default()),

--- a/src/v034/server.rs
+++ b/src/v034/server.rs
@@ -1,22 +1,25 @@
 use std::convert::{TryFrom, TryInto};
+use std::path::Path;
 
 use futures::future::{FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
 use futures::stream::{FuturesOrdered, StreamExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::{
-    net::{TcpListener, TcpStream, ToSocketAddrs},
+    net::{TcpListener, ToSocketAddrs, UnixListener},
     select,
 };
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tower::{Service, ServiceExt};
 
+use crate::BoxError;
 use tendermint::abci::MethodKind;
+
 use tendermint::v0_34::abci::{
     ConsensusRequest, ConsensusResponse, InfoRequest, InfoResponse, MempoolRequest,
     MempoolResponse, Request, Response, SnapshotRequest, SnapshotResponse,
 };
 
-use crate::BoxError;
 /// An ABCI server which listens for connections and forwards requests to four
 /// component ABCI [`Service`]s.
 pub struct Server<C, M, I, S> {
@@ -123,29 +126,54 @@ where
         ServerBuilder::default()
     }
 
-    pub async fn listen<A: ToSocketAddrs + std::fmt::Debug>(self, addr: A) -> Result<(), BoxError> {
-        tracing::info!(?addr, "starting ABCI server");
-        let listener = TcpListener::bind(addr).await?;
-        let local_addr = listener.local_addr()?;
-        tracing::info!(?local_addr, "bound tcp listener");
+    pub async fn listen_unix(self, path: impl AsRef<Path>) -> Result<(), BoxError> {
+        let listener = UnixListener::bind(path)?;
+        let addr = listener.local_addr()?;
+        tracing::info!(?addr, "ABCI server starting on uds");
 
         loop {
             match listener.accept().await {
                 Ok((socket, _addr)) => {
-                    // set parent: None for the connection span, as it should
-                    // exist independently of the listener's spans.
-                    //let span = tracing::span!(parent: None, Level::ERROR, "abci", ?addr);
+                    tracing::debug!(?_addr, "accepted new connection");
                     let conn = Connection {
                         consensus: self.consensus.clone(),
                         mempool: self.mempool.clone(),
                         info: self.info.clone(),
                         snapshot: self.snapshot.clone(),
                     };
-                    //tokio::spawn(async move { conn.run(socket).await.unwrap() }.instrument(span));
-                    tokio::spawn(async move { conn.run(socket).await.unwrap() });
+                    let (read, write) = socket.into_split();
+                    tokio::spawn(async move { conn.run(read, write).await.unwrap() });
                 }
                 Err(e) => {
-                    tracing::warn!({ %e }, "error accepting new tcp connection");
+                    tracing::error!({ %e }, "error accepting new connection");
+                }
+            }
+        }
+    }
+
+    pub async fn listen_tcp<A: ToSocketAddrs + std::fmt::Debug>(
+        self,
+        addr: A,
+    ) -> Result<(), BoxError> {
+        let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
+        tracing::info!(?addr, "ABCI server starting on tcp socket");
+
+        loop {
+            match listener.accept().await {
+                Ok((socket, _addr)) => {
+                    tracing::debug!(?_addr, "accepted new connection");
+                    let conn = Connection {
+                        consensus: self.consensus.clone(),
+                        mempool: self.mempool.clone(),
+                        info: self.info.clone(),
+                        snapshot: self.snapshot.clone(),
+                    };
+                    let (read, write) = socket.into_split();
+                    tokio::spawn(async move { conn.run(read, write).await.unwrap() });
+                }
+                Err(e) => {
+                    tracing::error!({ %e }, "error accepting new connection");
                 }
             }
         }
@@ -172,14 +200,18 @@ where
 {
     // XXX handle errors gracefully
     // figure out how / if to return errors to tendermint
-    async fn run(mut self, mut socket: TcpStream) -> Result<(), BoxError> {
+    async fn run(
+        mut self,
+        stream: impl AsyncReadExt + std::marker::Unpin,
+        sink: impl AsyncWriteExt + std::marker::Unpin,
+    ) -> Result<(), BoxError> {
         tracing::info!("listening for requests");
 
         use tendermint_proto::v0_34::abci as pb;
 
         let (mut request_stream, mut response_sink) = {
             use crate::v034::codec::{Decode, Encode};
-            let (read, write) = socket.split();
+            let (read, write) = (stream, sink);
             (
                 FramedRead::new(read, Decode::<pb::Request>::default()),
                 FramedWrite::new(write, Encode::<pb::Response>::default()),

--- a/src/v037/server.rs
+++ b/src/v037/server.rs
@@ -202,8 +202,8 @@ where
     // figure out how / if to return errors to tendermint
     async fn run(
         mut self,
-        stream: impl AsyncReadExt + std::marker::Unpin,
-        sink: impl AsyncWriteExt + std::marker::Unpin,
+        read: impl AsyncReadExt + std::marker::Unpin,
+        write: impl AsyncWriteExt + std::marker::Unpin,
     ) -> Result<(), BoxError> {
         tracing::info!("listening for requests");
 
@@ -211,7 +211,6 @@ where
 
         let (mut request_stream, mut response_sink) = {
             use crate::v037::codec::{Decode, Encode};
-            let (read, write) = (stream, sink);
             (
                 FramedRead::new(read, Decode::<pb::Request>::default()),
                 FramedWrite::new(write, Encode::<pb::Response>::default()),

--- a/src/v037/server.rs
+++ b/src/v037/server.rs
@@ -299,10 +299,13 @@ where
 
         match &socket {
             SocketKind::Tcp(tcp) => {
-                tracing::info!(addr = ?tcp.local_addr().ok(), "listening for tcp requests");
+                tracing::info!(
+                    addr = tcp.local_addr().ok().map(debug),
+                    "listening for tcp requests"
+                );
             }
             SocketKind::Uds(uds) => {
-                tracing::info!(addr = ?uds.local_addr().ok(), "listening for uds requests");
+                tracing::info!(addr = ?uds.local_addr().ok().map(debug), "listening for uds requests");
             }
         }
 

--- a/src/v037/server.rs
+++ b/src/v037/server.rs
@@ -1,16 +1,20 @@
 use std::convert::{TryFrom, TryInto};
+use std::io;
+use std::path::Path;
 
 use futures::future::{FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
 use futures::stream::{FuturesOrdered, StreamExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::{
-    net::{TcpListener, TcpStream, ToSocketAddrs},
+    net::{TcpListener, TcpStream, ToSocketAddrs, UnixListener, UnixStream},
     select,
 };
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tower::{Service, ServiceExt};
 
 use tendermint::abci::MethodKind;
+use tracing::warn;
 
 use crate::BoxError;
 
@@ -19,6 +23,43 @@ use tendermint::v0_37::abci::{
     MempoolResponse, Request, Response, SnapshotRequest, SnapshotResponse,
 };
 
+enum SocketKind {
+    Tcp(TcpStream),
+    Uds(UnixStream),
+}
+
+impl SocketKind {
+    fn split<'a>(
+        &'a mut self,
+    ) -> (
+        Box<dyn 'a + AsyncRead + Send + Unpin>,
+        Box<dyn 'a + AsyncWrite + Send + Unpin>,
+    ) {
+        match self {
+            Self::Tcp(tcp) => {
+                let (read, write) = tcp.split();
+                (Box::new(read), Box::new(write))
+            }
+            Self::Uds(uds) => {
+                let (read, write) = uds.split();
+                (Box::new(read), Box::new(write))
+            }
+        }
+    }
+}
+
+impl From<TcpStream> for SocketKind {
+    fn from(value: TcpStream) -> Self {
+        Self::Tcp(value)
+    }
+}
+
+impl From<UnixStream> for SocketKind {
+    fn from(value: UnixStream) -> Self {
+        Self::Uds(value)
+    }
+}
+
 /// An ABCI server which listens for connections and forwards requests to four
 /// component ABCI [`Service`]s.
 pub struct Server<C, M, I, S> {
@@ -26,6 +67,8 @@ pub struct Server<C, M, I, S> {
     mempool: M,
     info: I,
     snapshot: S,
+    tcp_listener: Option<TcpListener>,
+    uds_listener: Option<UnixListener>,
 }
 
 pub struct ServerBuilder<C, M, I, S> {
@@ -33,6 +76,8 @@ pub struct ServerBuilder<C, M, I, S> {
     mempool: Option<M>,
     info: Option<I>,
     snapshot: Option<S>,
+    tcp_listener: Option<TcpListener>,
+    uds_listener: Option<UnixListener>,
 }
 
 impl<C, M, I, S> Default for ServerBuilder<C, M, I, S> {
@@ -42,6 +87,8 @@ impl<C, M, I, S> Default for ServerBuilder<C, M, I, S> {
             mempool: None,
             info: None,
             snapshot: None,
+            tcp_listener: None,
+            uds_listener: None,
         }
     }
 }
@@ -86,17 +133,44 @@ where
         self
     }
 
+    pub fn tcp_listener(mut self, tcp_listener: TcpListener) -> Self {
+        self.tcp_listener = Some(tcp_listener);
+        self
+    }
+
+    pub async fn with_tcp_addr(mut self, addr: impl ToSocketAddrs) -> io::Result<Self> {
+        self.tcp_listener = Some(TcpListener::bind(addr).await?);
+        Ok(self)
+    }
+
+    pub fn uds_listener(mut self, uds_listener: UnixListener) -> Self {
+        self.uds_listener = Some(uds_listener);
+        self
+    }
+
+    pub fn with_uds_path(mut self, path: impl AsRef<Path>) -> io::Result<Self> {
+        self.uds_listener = Some(UnixListener::bind(path)?);
+        Ok(self)
+    }
+
     pub fn finish(self) -> Option<Server<C, M, I, S>> {
         let consensus = self.consensus?;
         let mempool = self.mempool?;
         let info = self.info?;
         let snapshot = self.snapshot?;
+        let tcp_listener = self.tcp_listener;
+        let uds_listener = self.uds_listener;
+        if tcp_listener.is_none() && uds_listener.is_none() {
+            return None;
+        }
 
         Some(Server {
             consensus,
             mempool,
             info,
             snapshot,
+            tcp_listener,
+            uds_listener,
         })
     }
 }
@@ -125,31 +199,77 @@ where
         ServerBuilder::default()
     }
 
-    pub async fn listen<A: ToSocketAddrs + std::fmt::Debug>(self, addr: A) -> Result<(), BoxError> {
-        tracing::info!(?addr, "starting ABCI server");
-        let listener = TcpListener::bind(addr).await?;
-        let local_addr = listener.local_addr()?;
-        tracing::info!(?local_addr, "bound tcp listener");
+    fn handle_new_connection(&self, socket: impl Into<SocketKind>) {
+        let socket = socket.into();
+        // set parent: None for the connection span, as it should
+        // exist independently of the listener's spans.
+        //let span = tracing::span!(parent: None, Level::ERROR, "abci", ?addr);
+        let conn = Connection {
+            consensus: self.consensus.clone(),
+            mempool: self.mempool.clone(),
+            info: self.info.clone(),
+            snapshot: self.snapshot.clone(),
+        };
+        //tokio::spawn(async move { conn.run(socket).await.unwrap() }.instrument(span));
+        tokio::spawn(async move { conn.run(socket).await.unwrap() });
+    }
+
+    pub async fn start(self) -> Result<(), BoxError> {
+        tracing::info!("starting ABCI server");
+
+        let tcp_addr = self
+            .tcp_listener
+            .as_ref()
+            .map(TcpListener::local_addr)
+            .transpose()
+            .map_err(|e| {
+                warn!(err.msg = %e, err.cause_chain = ?e, "failed getting tcp local addr");
+                e
+            })
+            .ok()
+            .flatten();
+        let uds_addr = self
+            .uds_listener
+            .as_ref()
+            .map(UnixListener::local_addr)
+            .transpose()
+            .map_err(|e| {
+                warn!(err.msg = %e, err.cause_chain = ?e, "failed getting uds local addr");
+                e
+            })
+            .ok()
+            .flatten();
+
+        tracing::info!(
+            addr.tcp = tcp_addr.map(debug),
+            addr.uds = uds_addr.map(debug),
+            "listening on local addresses"
+        );
 
         loop {
-            match listener.accept().await {
-                Ok((socket, _addr)) => {
-                    // set parent: None for the connection span, as it should
-                    // exist independently of the listener's spans.
-                    //let span = tracing::span!(parent: None, Level::ERROR, "abci", ?addr);
-                    let conn = Connection {
-                        consensus: self.consensus.clone(),
-                        mempool: self.mempool.clone(),
-                        info: self.info.clone(),
-                        snapshot: self.snapshot.clone(),
-                    };
-                    //tokio::spawn(async move { conn.run(socket).await.unwrap() }.instrument(span));
-                    tokio::spawn(async move { conn.run(socket).await.unwrap() });
+            select!(
+                tcp = async { self.tcp_listener.as_ref().unwrap().accept().await }, if self.tcp_listener.is_some() => {
+                    match tcp {
+                        Ok((socket, _addr)) => {
+                            self.handle_new_connection(socket);
+                        }
+                        Err(e) => {
+                            tracing::warn!({ %e }, "error accepting new tcp connection");
+                        }
+                    }
                 }
-                Err(e) => {
-                    tracing::warn!({ %e }, "error accepting new tcp connection");
+
+                uds = async { self.uds_listener.as_ref().unwrap().accept().await }, if self.uds_listener.is_some() => {
+                    match uds {
+                        Ok((socket, _addr)) => {
+                            self.handle_new_connection(socket);
+                        }
+                        Err(e) => {
+                            tracing::warn!({ %e }, "error accepting new uds connection");
+                        }
+                    }
                 }
-            }
+            )
         }
     }
 }
@@ -174,14 +294,21 @@ where
 {
     // XXX handle errors gracefully
     // figure out how / if to return errors to tendermint
-    async fn run(mut self, mut socket: TcpStream) -> Result<(), BoxError> {
-        tracing::info!("listening for requests");
-
+    async fn run(mut self, mut socket: SocketKind) -> Result<(), BoxError> {
         use tendermint_proto::v0_37::abci as pb;
+
+        match &socket {
+            SocketKind::Tcp(tcp) => {
+                tracing::info!(addr = ?tcp.local_addr().ok(), "listening for tcp requests");
+            }
+            SocketKind::Uds(uds) => {
+                tracing::info!(addr = ?uds.local_addr().ok(), "listening for uds requests");
+            }
+        }
 
         let (mut request_stream, mut response_sink) = {
             use crate::v037::codec::{Decode, Encode};
-            let (read, write) = socket.split();
+            let (read, write) = SocketKind::split(&mut socket);
             (
                 FramedRead::new(read, Decode::<pb::Request>::default()),
                 FramedWrite::new(write, Encode::<pb::Response>::default()),

--- a/src/v037/server.rs
+++ b/src/v037/server.rs
@@ -1,64 +1,24 @@
 use std::convert::{TryFrom, TryInto};
-use std::io;
 use std::path::Path;
 
 use futures::future::{FutureExt, TryFutureExt};
 use futures::sink::SinkExt;
 use futures::stream::{FuturesOrdered, StreamExt};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::{
-    net::{TcpListener, TcpStream, ToSocketAddrs, UnixListener, UnixStream},
+    net::{TcpListener, ToSocketAddrs, UnixListener},
     select,
 };
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tower::{Service, ServiceExt};
 
-use tendermint::abci::MethodKind;
-use tracing::warn;
-
 use crate::BoxError;
+use tendermint::abci::MethodKind;
 
 use tendermint::v0_37::abci::{
     ConsensusRequest, ConsensusResponse, InfoRequest, InfoResponse, MempoolRequest,
     MempoolResponse, Request, Response, SnapshotRequest, SnapshotResponse,
 };
-
-enum SocketKind {
-    Tcp(TcpStream),
-    Uds(UnixStream),
-}
-
-impl SocketKind {
-    fn split<'a>(
-        &'a mut self,
-    ) -> (
-        Box<dyn 'a + AsyncRead + Send + Unpin>,
-        Box<dyn 'a + AsyncWrite + Send + Unpin>,
-    ) {
-        match self {
-            Self::Tcp(tcp) => {
-                let (read, write) = tcp.split();
-                (Box::new(read), Box::new(write))
-            }
-            Self::Uds(uds) => {
-                let (read, write) = uds.split();
-                (Box::new(read), Box::new(write))
-            }
-        }
-    }
-}
-
-impl From<TcpStream> for SocketKind {
-    fn from(value: TcpStream) -> Self {
-        Self::Tcp(value)
-    }
-}
-
-impl From<UnixStream> for SocketKind {
-    fn from(value: UnixStream) -> Self {
-        Self::Uds(value)
-    }
-}
 
 /// An ABCI server which listens for connections and forwards requests to four
 /// component ABCI [`Service`]s.
@@ -67,8 +27,6 @@ pub struct Server<C, M, I, S> {
     mempool: M,
     info: I,
     snapshot: S,
-    tcp_listener: Option<TcpListener>,
-    uds_listener: Option<UnixListener>,
 }
 
 pub struct ServerBuilder<C, M, I, S> {
@@ -76,8 +34,6 @@ pub struct ServerBuilder<C, M, I, S> {
     mempool: Option<M>,
     info: Option<I>,
     snapshot: Option<S>,
-    tcp_listener: Option<TcpListener>,
-    uds_listener: Option<UnixListener>,
 }
 
 impl<C, M, I, S> Default for ServerBuilder<C, M, I, S> {
@@ -87,8 +43,6 @@ impl<C, M, I, S> Default for ServerBuilder<C, M, I, S> {
             mempool: None,
             info: None,
             snapshot: None,
-            tcp_listener: None,
-            uds_listener: None,
         }
     }
 }
@@ -133,44 +87,17 @@ where
         self
     }
 
-    pub fn tcp_listener(mut self, tcp_listener: TcpListener) -> Self {
-        self.tcp_listener = Some(tcp_listener);
-        self
-    }
-
-    pub async fn with_tcp_addr(mut self, addr: impl ToSocketAddrs) -> io::Result<Self> {
-        self.tcp_listener = Some(TcpListener::bind(addr).await?);
-        Ok(self)
-    }
-
-    pub fn uds_listener(mut self, uds_listener: UnixListener) -> Self {
-        self.uds_listener = Some(uds_listener);
-        self
-    }
-
-    pub fn with_uds_path(mut self, path: impl AsRef<Path>) -> io::Result<Self> {
-        self.uds_listener = Some(UnixListener::bind(path)?);
-        Ok(self)
-    }
-
     pub fn finish(self) -> Option<Server<C, M, I, S>> {
         let consensus = self.consensus?;
         let mempool = self.mempool?;
         let info = self.info?;
         let snapshot = self.snapshot?;
-        let tcp_listener = self.tcp_listener;
-        let uds_listener = self.uds_listener;
-        if tcp_listener.is_none() && uds_listener.is_none() {
-            return None;
-        }
 
         Some(Server {
             consensus,
             mempool,
             info,
             snapshot,
-            tcp_listener,
-            uds_listener,
         })
     }
 }
@@ -199,77 +126,56 @@ where
         ServerBuilder::default()
     }
 
-    fn handle_new_connection(&self, socket: impl Into<SocketKind>) {
-        let socket = socket.into();
-        // set parent: None for the connection span, as it should
-        // exist independently of the listener's spans.
-        //let span = tracing::span!(parent: None, Level::ERROR, "abci", ?addr);
-        let conn = Connection {
-            consensus: self.consensus.clone(),
-            mempool: self.mempool.clone(),
-            info: self.info.clone(),
-            snapshot: self.snapshot.clone(),
-        };
-        //tokio::spawn(async move { conn.run(socket).await.unwrap() }.instrument(span));
-        tokio::spawn(async move { conn.run(socket).await.unwrap() });
-    }
-
-    pub async fn start(self) -> Result<(), BoxError> {
-        tracing::info!("starting ABCI server");
-
-        let tcp_addr = self
-            .tcp_listener
-            .as_ref()
-            .map(TcpListener::local_addr)
-            .transpose()
-            .map_err(|e| {
-                warn!(err.msg = %e, err.cause_chain = ?e, "failed getting tcp local addr");
-                e
-            })
-            .ok()
-            .flatten();
-        let uds_addr = self
-            .uds_listener
-            .as_ref()
-            .map(UnixListener::local_addr)
-            .transpose()
-            .map_err(|e| {
-                warn!(err.msg = %e, err.cause_chain = ?e, "failed getting uds local addr");
-                e
-            })
-            .ok()
-            .flatten();
-
-        tracing::info!(
-            addr.tcp = tcp_addr.map(debug),
-            addr.uds = uds_addr.map(debug),
-            "listening on local addresses"
-        );
+    pub async fn listen_unix(self, path: impl AsRef<Path>) -> Result<(), BoxError> {
+        let listener = UnixListener::bind(path)?;
+        let addr = listener.local_addr()?;
+        tracing::info!(?addr, "ABCI server starting on uds");
 
         loop {
-            select!(
-                tcp = async { self.tcp_listener.as_ref().unwrap().accept().await }, if self.tcp_listener.is_some() => {
-                    match tcp {
-                        Ok((socket, _addr)) => {
-                            self.handle_new_connection(socket);
-                        }
-                        Err(e) => {
-                            tracing::warn!({ %e }, "error accepting new tcp connection");
-                        }
-                    }
+            match listener.accept().await {
+                Ok((socket, _addr)) => {
+                    tracing::debug!(?_addr, "accepted new connection");
+                    let conn = Connection {
+                        consensus: self.consensus.clone(),
+                        mempool: self.mempool.clone(),
+                        info: self.info.clone(),
+                        snapshot: self.snapshot.clone(),
+                    };
+                    let (read, write) = socket.into_split();
+                    tokio::spawn(async move { conn.run(read, write).await.unwrap() });
                 }
+                Err(e) => {
+                    tracing::error!({ %e }, "error accepting new connection");
+                }
+            }
+        }
+    }
 
-                uds = async { self.uds_listener.as_ref().unwrap().accept().await }, if self.uds_listener.is_some() => {
-                    match uds {
-                        Ok((socket, _addr)) => {
-                            self.handle_new_connection(socket);
-                        }
-                        Err(e) => {
-                            tracing::warn!({ %e }, "error accepting new uds connection");
-                        }
-                    }
+    pub async fn listen_tcp<A: ToSocketAddrs + std::fmt::Debug>(
+        self,
+        addr: A,
+    ) -> Result<(), BoxError> {
+        let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
+        tracing::info!(?addr, "ABCI server starting on tcp socket");
+
+        loop {
+            match listener.accept().await {
+                Ok((socket, _addr)) => {
+                    tracing::debug!(?_addr, "accepted new connection");
+                    let conn = Connection {
+                        consensus: self.consensus.clone(),
+                        mempool: self.mempool.clone(),
+                        info: self.info.clone(),
+                        snapshot: self.snapshot.clone(),
+                    };
+                    let (read, write) = socket.into_split();
+                    tokio::spawn(async move { conn.run(read, write).await.unwrap() });
                 }
-            )
+                Err(e) => {
+                    tracing::error!({ %e }, "error accepting new connection");
+                }
+            }
         }
     }
 }
@@ -294,24 +200,18 @@ where
 {
     // XXX handle errors gracefully
     // figure out how / if to return errors to tendermint
-    async fn run(mut self, mut socket: SocketKind) -> Result<(), BoxError> {
-        use tendermint_proto::v0_37::abci as pb;
+    async fn run(
+        mut self,
+        stream: impl AsyncReadExt + std::marker::Unpin,
+        sink: impl AsyncWriteExt + std::marker::Unpin,
+    ) -> Result<(), BoxError> {
+        tracing::info!("listening for requests");
 
-        match &socket {
-            SocketKind::Tcp(tcp) => {
-                tracing::info!(
-                    addr = tcp.local_addr().ok().map(debug),
-                    "listening for tcp requests"
-                );
-            }
-            SocketKind::Uds(uds) => {
-                tracing::info!(addr = ?uds.local_addr().ok().map(debug), "listening for uds requests");
-            }
-        }
+        use tendermint_proto::v0_37::abci as pb;
 
         let (mut request_stream, mut response_sink) = {
             use crate::v037::codec::{Decode, Encode};
-            let (read, write) = SocketKind::split(&mut socket);
+            let (read, write) = (stream, sink);
             (
                 FramedRead::new(read, Decode::<pb::Request>::default()),
                 FramedWrite::new(write, Encode::<pb::Response>::default()),


### PR DESCRIPTION
This patch allows the v037 server to serve cometbft connecting over unix domain sockets in addition to TCP.

`Server::listen` no longer has a tcp socket addr as argument. Instead, TCP and UDS listeners are set on `ServerBuilder`. They are complimentary and `Server` can serve requests over either or both protocols.

If neither TCP nor UDS are set `ServerBuilder::finish` returns `None` if neither are set. This seems in line with the current behavior of `ServerBuilder`, but more expressive errors would be nice (but not in this PR).

Note that when shuffling the code around I left the original commented out lines in place. Happy to remove them, but they probably serve a purpose.

Open question: should the v034 also support UDS?