### PR TITLE
tower-abci: update tendermint bindings and prost version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.33"
-tendermint = "0.33"
+tendermint-proto = "0.34"
+tendermint = "0.34"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }
@@ -21,7 +21,7 @@ tower = { version = "0.4", features = ["full"]}
 pin-project = "1"
 futures = "0.3"
 tracing = "0.1"
-prost = "0.11"
+prost = "0.12"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Henry de Valence <hdevalence@penumbra.zone>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This PR uses `prost@0.12` and `tendermint-rs@0.34` as well as bumping a major version of the crate.