### PR TITLE
server: 🌽 `listen_channel` for in-memory connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ tracing-subscriber = "0.3.17"
 
 [features]
 doc = []
+local = []
 


### PR DESCRIPTION
this introduces a `Server::listen_channel` interface. this is like the existing `listen_tcp` or `listen_unix` methods, but instead applies to an in-memory channel of `(read, write)` tuples.

this is motivated by work like penumbra-zone/penumbra#3588. to summarize the motivation, it would be nice if we had a way to run a tower-abci service in cargo tests, without needing to bind to an actual port, or create a unix-domain socket within a temporary directory.