### PR TITLE
tower-abci: prepare release `v0.12.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Henry de Valence <hdevalence@penumbra.zone>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This prepare release `v0.12`.