### PR TITLE
docs: comments about consensus concurrency control

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ application task.
 At this level the developer must pay closer attention to utilising Tower
 layers to control the concurrency of the individual services mentioned above.
 In particular the `Consensus` service should be wrapped with
-`ServiceBuilder::concurrency_limit` to avoid a potential reordering of
-consensus message effects caused by concurrent execution.
+`ServiceBuilder::concurrency_limit` of 1 to avoid a potential reordering of
+consensus message effects caused by concurrent execution, as well as
+`ServiceBuilder::buffer` to avoid any deadlocks in message handling in `Connection`
+due to the limited concurrency.
 
 3. At the highest level of complexity, application developers can implement
 multiple distinct `Service`s and manually control synchronization of shared

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ processing of some requests by immediately returning a future that will be
 executed on the caller's task. Although all requests are still received by
 the application task, not all request processing needs to happen on the
 application task.
+At this level the developer must pay closer attention to utilising Tower
+layers to control the concurrency of the individual services mentioned above.
+In particular the `Consensus` service should be wrapped with
+`ServiceBuilder::concurrency_limit` to avoid a potential reordering of
+consensus message effects caused by concurrent execution.
 
 3. At the highest level of complexity, application developers can implement
 multiple distinct `Service`s and manually control synchronization of shared

--- a/examples/kvstore_34/main.rs
+++ b/examples/kvstore_34/main.rs
@@ -158,6 +158,9 @@ async fn main() {
     // Hand those components to the ABCI server, but customize request behavior
     // for each category -- for instance, apply load-shedding only to mempool
     // and info requests, but not to consensus requests.
+    // Note that this example use synchronous execution in `Service::call`, wrapping the end result in a ready future.
+    // If `Service::call` did the actual request handling inside the `async` block as well, then the `consensus` service
+    // below should be wrapped with a `ServiceBuilder::concurrency_limit` to avoid any unintended reordering of message effects.
     let server_builder = Server::builder()
         .consensus(consensus)
         .snapshot(snapshot)

--- a/examples/kvstore_37/main.rs
+++ b/examples/kvstore_37/main.rs
@@ -165,6 +165,9 @@ async fn main() {
     // Hand those components to the ABCI server, but customize request behavior
     // for each category -- for instance, apply load-shedding only to mempool
     // and info requests, but not to consensus requests.
+    // Note that this example use synchronous execution in `Service::call`, wrapping the end result in a ready future.
+    // If `Service::call` did the actual request handling inside the `async` block as well, then the `consensus` service
+    // below should be wrapped with a `ServiceBuilder::concurrency_limit` to avoid any unintended reordering of message effects.
     let server_builder = Server::builder()
         .consensus(consensus)
         .snapshot(snapshot)

--- a/examples/kvstore_38/main.rs
+++ b/examples/kvstore_38/main.rs
@@ -207,6 +207,9 @@ async fn main() {
     // Hand those components to the ABCI server, but customize request behavior
     // for each category -- for instance, apply load-shedding only to mempool
     // and info requests, but not to consensus requests.
+    // Note that this example use synchronous execution in `Service::call`, wrapping the end result in a ready future.
+    // If `Service::call` did the actual request handling inside the `async` block as well, then the `consensus` service
+    // below should be wrapped with a `ServiceBuilder::concurrency_limit` to avoid any unintended reordering of message effects.
     let server_builder = Server::builder()
         .consensus(consensus)
         .snapshot(snapshot)

--- a/src/buffer4/service.rs
+++ b/src/buffer4/service.rs
@@ -62,6 +62,12 @@ where
     /// [`poll_ready`] but will not issue a [`call`], which prevents other senders from issuing new
     /// requests.
     ///
+    /// # A note on the scope of `bound`
+    ///
+    /// Note that `bound` will only limit the rate of the _submission_ of [Message]s to the [Worker],
+    /// not their _execution_. If the execution itself is asynchronous, concurrency should be further
+    /// controlled by applying an appropriate [tower::Layer] on the returned service component.
+    ///
     /// [`Poll::Ready`]: std::task::Poll::Ready
     /// [`call`]: crate::Service::call
     /// [`poll_ready`]: crate::Service::poll_ready


### PR DESCRIPTION
Closes #44 

Added comments to all examples, the main README and the `Buffer` to mention that Tower layering should be used to control the concurrency of the `Consensus` service if the implementation of request handling in `call` of the actual application service is asynchronous. 

An example of an asynchronous implementation is [here](https://github.com/consensus-shipyard/ipc/tree/1ec4a1d9b3616d4cea831ae21eb2902a116b9b04/fendermint/abci), which exhibited transaction reordering.

### Implementation notes

I found that I needed to do the following combo to make it work with ABCI++ in v0.37:
* Pass `ServiceBuilder::new().buffer(block_max_msgs + 3).concurrency_limit(1).service(consensus)` to the `ServiceBuilder`, where the `buffer` serves to allow all messages in a block lifecycle to be queued up without blocking `Connection::run`
* Enforce the `block_max_msgs` setting in `prepare_proposal` and `process_proposal` so we don't get blocks which would violate that assumption.
* Notably without `.buffer`, we got a deadlock because the responses weren't processed by `Connection`, and I suppose this applies to undersized buffers as well, which is why I added the proposal handling too. 

This shouldn't be an issue with v0.38 which uses `finalize_block`.

I thought about adding it as an example to `kvstore_037` but it would needlessly complicate it, as it's immune by the virtue of being synchronous.