### PR TITLE
Bump to tendermint 0.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.35"
-tendermint = "0.35"
+tendermint-proto = "0.36"
+tendermint = "0.36"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }


### PR DESCRIPTION
I have to submit a similar PR. Sorry for the mess.
`tendermint-rs` `0.36.0` has been released. We want to use it.