### PR TITLE
tower-abci: bump `tendermint@0.39`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.16.0"
+version = "0.17.0"
 authors = [
   "Penumbra Labs <team@penumbralabs.xyz>",
   "Henry de Valence <hdevalence@penumbralabs.xyz"
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.38"
-tendermint = "0.38"
+tendermint-proto = "0.39"
+tendermint = "0.39"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::doc_lazy_continuation)]
 #![doc = include_str!("../README.md")]
 /// A fork of tower::buffer @ `e1760d38` that has four queues feeding
 /// the same worker task, with different priorities.


### PR DESCRIPTION
This bumps `tendermint-rs` and `tendermint-proto` to `v0.39.x` and prepare the `v0.17.0` release of the crate. 