### PR TITLE
tower-abci: bump to `tendermint@0.40`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-abci"
-version = "0.17.0"
+version = "0.18.0"
 authors = [
   "Penumbra Labs <team@penumbralabs.xyz>",
   "Henry de Valence <hdevalence@penumbralabs.xyz"
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/tower-abci"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tendermint-proto = "0.39"
-tendermint = "0.39"
+tendermint-proto = "0.40"
+tendermint = "0.40"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tokio-util = { version = "0.6", features = ["codec"] }


### PR DESCRIPTION
Preparing release `v0.18.0` featuring `tendermint@0.40` and `tendermint-proto@0.40`.

